### PR TITLE
fixed: fail to retrieve File and Dir status from server

### DIFF
--- a/src/connection/RC_directory.class.php
+++ b/src/connection/RC_directory.class.php
@@ -189,7 +189,7 @@ trait RC_directory {
         $que_result = $this->genQuery(
                 array("COL_COLL_NAME", "COL_COLL_ID", "COL_COLL_OWNER_NAME",
             "COL_COLL_OWNER_ZONE", "COL_COLL_CREATE_TIME", "COL_COLL_MODIFY_TIME",
-            "COL_COLL_TYPE", "COL_COLL_INFO1", "COL_COLL_INFO2", "COL_COLL_COMMENTS"), $cond, array(), 0, 1, false);
+            "COL_COLL_TYPE", "COL_COLL_INFO1", "COL_COLL_INFO2", "COL_COLL_COMMENTS"), $cond, array(), 0, 2, false);
         if ($que_result === false)
             return false;
 

--- a/src/connection/RC_file.class.php
+++ b/src/connection/RC_file.class.php
@@ -97,7 +97,7 @@ trait RC_file {
                 array("COL_DATA_NAME", "COL_D_DATA_ID", "COL_DATA_TYPE_NAME",
             "COL_D_RESC_NAME", "COL_DATA_SIZE", "COL_D_OWNER_NAME", "COL_D_OWNER_ZONE",
             "COL_D_CREATE_TIME",
-            "COL_D_MODIFY_TIME", "COL_D_COMMENTS"), $cond, array(), 0, 1, false);
+            "COL_D_MODIFY_TIME", "COL_D_COMMENTS"), $cond, array(), 0, 2, false);
         if ($que_result === false)
             return false;
 


### PR DESCRIPTION
I am using irods-php to connect to an iRODS 4.2.4 instance.
I was attempting to retrieve the stats of objects and collections using the following code:
```
<?php
require_once("../vendor/irods-php/src/autoload.inc.php");

$account = new RODSAccount('irods', 1247, "rods", "test", "tempZone", "demoResc", "Native");

$filepath = "/tempZone/home/rods/README.md";
print($filepath);
$myfile = new ProdsFile($account, $filepath);
$stats = $myfile->getStats();
print_r($stats);

$filepath = "/tempZone/home/rods";
print($filepath);
$myfile = new ProdsDir($account, $filepath);
$stats = $myfile->getStats();
print_r($stats);
```
This scripts failed with the following error message on the backend:

```
pid:2198 remote addresses: 172.18.0.5, 172.18.0.8 ERROR: [-]    /tmp/tmpkfeEjV/server/core/src/rsApiHandler.cpp:540:int readAndProcClientMsg(rsComm_t *, int) :  status [SYS_HEADER_READ_LEN_ERR]  errno [] -- message [only read [1] of [4]]
        [-]     /tmp/tmpkfeEjV/lib/core/src/sockComm.cpp:201:irods::error readMsgHeader(irods::network_object_ptr, msgHeader_t *, struct timeval *) :  status [SYS_HEADER_READ_LEN_ERR]  errno [] -- message [only read [1] of [4]]
                [-]     /tmp/tmpkfeEjV/plugins/network/tcp/libtcp.cpp:194:irods::error tcp_read_msg_header(irods::plugin_context &, void *, struct timeval *) :  status [SYS_HEADER_READ_LEN_ERR]  errno [] -- message [only read [1] of [4]]

```

Apparently there was something wrong with the message encoding. I've fixed it by increasing the max. results of the Query from 1 to 2. I don't know the exact reason why a max result of 1 fails but I suspect it is rather related to the iRODS backend than to the irods-php client.

The workaround  in this pull request works for me. Can you check if you may want to include it into the upstream repo?
There might still be other locations in the code base with the same problem.